### PR TITLE
Setup Code Climate with Actions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -17,6 +17,10 @@ jobs:
       run: bundle install
     - name: Run tests
       run: bundle exec rake
+    - name: Submit coverage
+      uses: paambaati/codeclimate-action@v2.7.5
+      env:
+        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
     - name: Deploy
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       run: |
@@ -28,4 +32,3 @@ jobs:
         gem push *.gem
       env:
         GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
-

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.class
 hs_*.log
 Gemfile.lock
+coverage

--- a/mumuki-wollok-runner.gemspec
+++ b/mumuki-wollok-runner.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'simplecov', '~> 0.17.0'
   spec.add_development_dependency 'mumukit-bridge', '~> 3.1'
 end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 require 'active_support/all'
 require 'mumukit/bridge'
 

--- a/spec/query_hook_spec.rb
+++ b/spec/query_hook_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 require_relative '../lib/wollok_runner'
 
 describe WollokQueryHook do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'simplecov'
+SimpleCov.start

--- a/spec/testhook_spec.rb
+++ b/spec/testhook_spec.rb
@@ -1,3 +1,4 @@
+require_relative 'spec_helper'
 require_relative '../lib/wollok_runner'
 
 describe WollokTestHook do


### PR DESCRIPTION
`simplecov` needs to be fixed to 1.17.x because of a [compatibility issue with codeclimate test reporter](https://github.com/codeclimate/test-reporter/issues/413).

Tbh I'm not really happy with adding this to the same job (or workflow even).
Our current options seem to be:
- doing this
- or setting up separate jobs/workflows but repeating the common steps/config in each of them.

That is at least until this is done: https://github.com/actions/runner/issues/646.